### PR TITLE
Limit supported machines

### DIFF
--- a/airsonos/config.json
+++ b/airsonos/config.json
@@ -11,6 +11,19 @@
     "armhf",
     "i386"
   ],
+  "machine": [
+    "intel-nuc",
+    "qemux86",
+    "qemux86-64",
+    "qemuarm",
+    "qemuarm-64",
+    "raspberrypi2",
+    "raspberrypi3",
+    "raspberrypi3-64",
+    "tinker",
+    "odroid-c2",
+    "odroid-xu"
+  ],
   "boot": "auto",
   "hassio_api": true,
   "homeassistant_api": false,


### PR DESCRIPTION
# Proposed Changes

Most ARM-based devices are supported, but a ARMv6 is not.
This PR changes the config.json to limit that.
Support for this was added to Hass.io in v132 (https://github.com/home-assistant/hassio/pull/720).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/