### PR TITLE
Change PCM to WAV for comaptibility w/latest Sonos

### DIFF
--- a/airsonos/rootfs/etc/airsonos.xml
+++ b/airsonos/rootfs/etc/airsonos.xml
@@ -4,7 +4,7 @@
 <enabled>1</enabled>
 <stop_receiver>0</stop_receiver>
 <latency></latency>
-<codec>pcm</codec>
+<codec>wav</codec>
 <artwork></artwork>
 </common>
 <main_log>info</main_log>


### PR DESCRIPTION
# Proposed Changes

Change encoding format from PCM to WAV, as latest sonos release does not work with WAV

## Related Issues

https://github.com/hassio-addons/addon-airsonos/issues/134
https://github.com/philippe44/AirConnect/issues/458

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
