### PR TITLE
Migrate AirSonos config out of Home Assistant config folder

### DIFF
--- a/airsonos/DOCS.md
+++ b/airsonos/DOCS.md
@@ -168,8 +168,8 @@ lack of audio. Note that `latency_rtp` does not delay playback start.
 
 ## Tweaking AirSonos
 
-AirSonos creates a configuration file called `airsonos.xml` in your Home
-Assistant configuration directory. This file allows you to tweak each device
+AirSonos creates a configuration file called `airsonos.xml` in the add-on
+configuration directory. This file allows you to tweak each device
 separately. Every time it finds a new device, it will be added to that file.
 
 > **NOTE**: It is HIGHLY recommended to stop the addon before making changes

--- a/airsonos/config.yaml
+++ b/airsonos/config.yaml
@@ -14,7 +14,8 @@ arch:
 hassio_api: true
 host_network: true
 map:
-  - config:rw
+  - addon_config:rw
+  - homeassistant_config:rw
 options:
   port: 49152
   latency_rtp: 1000

--- a/airsonos/rootfs/etc/s6-overlay/s6-rc.d/init-airsonos/run
+++ b/airsonos/rootfs/etc/s6-overlay/s6-rc.d/init-airsonos/run
@@ -6,6 +6,14 @@
 # ==============================================================================
 declare latency
 
+# Migrate add-on data from the Home Assistant config folder,
+# to the add-on configuration folder.
+if ! bashio::fs.directory_exists '/config/airsonos.xml' \
+    && bashio::fs.file_exists '/homeassistant/airsonos.xml'; then
+    mv /homeassistant/airsonos.xml /config/airsonos.xml \
+        || bashio::exit.nok "Failed to migrate AirSonos configuration"
+fi
+
 # Create a configuration file, if it does not exist yet
 if ! bashio::fs.file_exists '/config/airsonos.xml'; then
     cp /etc/airsonos.xml /config/airsonos.xml


### PR DESCRIPTION
# Proposed Changes

This moves the Aircast configuration out of the Home Assistant configuration folder into its own add-on configuration folder. This ensures the configuration is included in the add-on backups as well.
