### PR TITLE
🔨 Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["//Dockerfile$/"],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
+      ],
+      "versioningTemplate": "deb",
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["//Dockerfile$/"],
       "matchStrings": [
         "ARG AIRCONNECT_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
       ],
@@ -28,6 +39,15 @@
     }
   ],
   "packageRules": [
+    {
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
+      "automerge": true
+    },
     {
       "groupName": "App base image",
       "matchDatasources": ["docker"]


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Mirrors hassio-addons/app-vaultwarden#447 here, following hassio-addons/app-aircast#256. As in aircast, this repository never had a `repology` manager to begin with, so this is not a swap but an addition.

The `Dockerfile` pins `unzip=6.0-29`, but none of the custom managers in `renovate.json` ever matched an apt pin, so that pin has been sitting there untracked since it was introduced. This adds the apt manager using Renovate's native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/), which reads the Debian package indices directly. It indexes **binary** package names, so `depNameTemplate` is plain `{{{package}}}` and no source package name mapping is needed. Going straight to `deb` also skips the Repology throttling and timeout problems that prompted the vaultwarden change.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three are aggregated rather than first one wins.

### Known limitation

Same as in the vaultwarden and aircast PRs: the datasource currently hardcodes `Packages.gz`, while `trixie-updates` and `trixie-security` serve only `Packages.xz`, so those two suites are inert until renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

There is no practical impact here. Checked against the Debian madison API: `unzip` resolves from `trixie` `main` at `6.0-29`, with nothing in `trixie-updates` or `trixie-security`. That is the suite that does work today, so the repository's only apt pin is tracked from the moment this merges.

### Validation

- `renovate-config-validator --strict` from Renovate 44.x: `Config validated successfully against 1 file(s)`.
- Ran the manager's regex against `airsonos/Dockerfile` to confirm the intended scope: exactly one match, `package=unzip` / `currentValue=6.0-29`. The uppercase `ARG` values and the dotted `LABEL` keys do not match, so no spurious dependencies are picked up.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Reflects hassio-addons/app-vaultwarden#447 and hassio-addons/app-aircast#256.

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated detection and resolution of Debian package versions in Dockerfiles.
  * Enabled automatic merging for eligible Debian package updates from Trixie, updates, and security repositories on amd64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->